### PR TITLE
Fix batch_size type error

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ flags.DEFINE_string("tag_schema",   "iobes",    "tagging schema iobes or iob")
 # configurations for training
 flags.DEFINE_float("clip",          5,          "Gradient clip")
 flags.DEFINE_float("dropout",       0.5,        "Dropout rate")
-flags.DEFINE_float("batch_size",    20,         "batch size")
+flags.DEFINE_integer("batch_size",  20,         "batch size")
 flags.DEFINE_float("lr",            0.001,      "Initial learning rate")
 flags.DEFINE_string("optimizer",    "adam",     "Optimizer for training")
 flags.DEFINE_boolean("pre_emb",     True,       "Wither use pre-trained embedding")


### PR DESCRIPTION
When doing
```bash
python3 main.py --train=True --clean=True
```

Got the following error
```python
Traceback (most recent call last):
  File "main.py", line 225, in <module>
    tf.app.run(main)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/platform/app.py", line 125, in run
    _sys.exit(main(argv))
  File "main.py", line 219, in main
    train()
  File "main.py", line 150, in train
    train_manager = BatchManager(train_data, FLAGS.batch_size)
  File "/home/elvis/workspace/ChineseNER/data_utils.py", line 285, in __init__
    self.batch_data = self.sort_and_pad(data, batch_size)
  File "/home/elvis/workspace/ChineseNER/data_utils.py", line 293, in sort_and_pad
    batch_data.append(self.pad_data(sorted_data[i*batch_size : (i+1)*batch_size]))
TypeError: slice indices must be integers or None or have an __index__ method
```

To solve it, I changed the type of tf flag `batch_size` to integer.